### PR TITLE
fix(node10): upgrade chokidar to pass node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "should": "~4.0.0"
   },
   "dependencies": {
-    "chokidar": "^2.0.2",
+    "chokidar": "^2.0.4",
     "debug": "^3.1.0",
     "ignore-by-default": "^1.0.1",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
upath (dependency from chokidar) has failed on many packages because it
was requiring node < 10. Now that upath got updated, chokidar got it too
and we can safely upgrade.

I did not regenerate the package-lock.json file because it was changing
it in a very weird way. I believe it was generated with some nodejs
version I don't have.

I suggest for this to use .nvmrc with a static version so that you can
control the nodejs version used by your contributors and will ease the
process.